### PR TITLE
Fixes handling of non utf8 encoded wsdl files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 coverage.out
+.idea
+.vscode

--- a/soap_test.go
+++ b/soap_test.go
@@ -153,6 +153,18 @@ func TestClient_Call(t *testing.T) {
 	}
 }
 
+func TestClient_Call_NonUtf8(t *testing.T) {
+	soap, err := SoapClient("https://www.demo.ilias.de/webservice/soap/server.php?wsdl")
+	if err != nil {
+		t.Errorf("error not expected: %s", err)
+	}
+
+	soap.Call("login", Params{"client": "demo", "username": "robert", "password": "iliasdemo"})
+	if err != nil {
+		t.Errorf("error in soap call: %s", err)
+	}
+}
+
 func TestClient_doRequest(t *testing.T) {
 	c := &Client{}
 

--- a/wsdl.go
+++ b/wsdl.go
@@ -2,8 +2,8 @@ package gosoap
 
 import (
 	"encoding/xml"
-	"io/ioutil"
 	"net/http"
+	"golang.org/x/net/html/charset"
 )
 
 type wsdlDefinitions struct {
@@ -152,7 +152,7 @@ type xsdMaxInclusive struct {
 	Value string `xml:"value,attr"`
 }
 
-// getwsdlDefinitions sent request to the wsdl url and set definitions on struct
+// getWsdlDefinitions sent request to the wsdl url and set definitions on struct
 func getWsdlDefinitions(u string) (wsdl *wsdlDefinitions, err error) {
 	r, err := http.Get(u)
 	if err != nil {
@@ -160,8 +160,9 @@ func getWsdlDefinitions(u string) (wsdl *wsdlDefinitions, err error) {
 	}
 	defer r.Body.Close()
 
-	b, _ := ioutil.ReadAll(r.Body)
-	err = xml.Unmarshal(b, &wsdl)
+	decoder := xml.NewDecoder(r.Body)
+	decoder.CharsetReader = charset.NewReaderLabel
+	err = decoder.Decode(&wsdl)
 
 	return wsdl, err
 }


### PR DESCRIPTION
Great library Tiago! I using it to write a client library for https://www.demo.ilias.de/ and encountered the parsing error. This PR fixes the error
`xml: encoding "ISO-8859-1" declared but Decoder.CharsetReader is nil`

- Fixes handling of non-utf8 encoded wsdl files
- Added tests
- add ide folders to ignore