### PR TITLE
Return errors if definitions/services not found in wsdl definitions

### DIFF
--- a/soap.go
+++ b/soap.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
+	"github.com/pkg/errors"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -64,6 +65,14 @@ func (c *Client) GetLastRequest() []byte {
 
 // Call call's the method m with Params p
 func (c *Client) Call(m string, p Params) (err error) {
+	if c.Definitions == nil {
+		return errors.New("WSDL definitions not found.")
+	}
+
+	if c.Definitions.Services == nil {
+		return errors.New("No Services found in WSDL definitions.")
+	}
+
 	c.Method = m
 	c.Params = p
 	c.SoapAction = c.Definitions.GetSoapActionFromWsdlOperation(c.Method)

--- a/soap.go
+++ b/soap.go
@@ -3,8 +3,8 @@ package gosoap
 import (
 	"bytes"
 	"encoding/xml"
+	"errors"
 	"fmt"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -41,7 +41,7 @@ func SoapClient(wsdl string) (*Client, error) {
 // Client struct hold all the informations about WSDL,
 // request and response of the server
 type Client struct {
-	HttpClient 	 *http.Client
+	HttpClient   *http.Client
 	WSDL         string
 	URL          string
 	Method       string
@@ -66,11 +66,11 @@ func (c *Client) GetLastRequest() []byte {
 // Call call's the method m with Params p
 func (c *Client) Call(m string, p Params) (err error) {
 	if c.Definitions == nil {
-		return errors.New("WSDL definitions not found.")
+		return errors.New("WSDL definitions not found")
 	}
 
 	if c.Definitions.Services == nil {
-		return errors.New("No Services found in WSDL definitions.")
+		return errors.New("No Services found in WSDL definitions")
 	}
 
 	c.Method = m


### PR DESCRIPTION
This PR adds 2 error checks to the SOAP `Client.Call` function.

1. Checks if `Client.Definitions` exists
2. Checks if `Client.Definitions.Service` exists.

It aims to solve 2 error-able cases:

1. When the WSDL definitions are empty, return an error e.g. At #14 
2. When the `Client.Call` function is called with an empty `Client`. e.g. At #13 