### PR TITLE
Refactored Soap, made it more concurrent friendly and other improvement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ func main() {
 		"IPAddress": "8.8.8.8",
 	}
 
-	err = soap.Call("GetGeoIP", params)
+	res, err := soap.Call("GetGeoIP", params)
 	if err != nil {
 		fmt.Errorf("error in soap call: %s", err)
 	}
 
-	soap.Unmarshal(&r)
+	res.Unmarshal(&r)
 	if r.GetGeoIPResult.CountryCode != "USA" {
 		fmt.Errorf("error: %+v", r)
 	}

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ func main() {
 		fmt.Errorf("error in soap call: %s", err)
 	}
 
-    r := GetGeoIPResponse{}
+	r := GetGeoIPResponse{}
 
 	res.Unmarshal(&r)
 	if r.GetGeoIPResult.CountryCode != "USA" {

--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ type GetGeoIPResult struct {
 	CountryCode       string
 }
 
-var (
-	r GetGeoIPResponse
-)
-
 func main() {
 	soap, err := gosoap.SoapClient("http://www.webservicex.net/geoipservice.asmx?WSDL")
 	if err != nil {
@@ -47,6 +43,8 @@ func main() {
 	if err != nil {
 		fmt.Errorf("error in soap call: %s", err)
 	}
+
+    r := GetGeoIPResponse{}
 
 	res.Unmarshal(&r)
 	if r.GetGeoIPResult.CountryCode != "USA" {

--- a/encode.go
+++ b/encode.go
@@ -8,7 +8,6 @@ import (
 
 // MarshalXML envelope the body and encode to xml
 func (c process) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
-
 	tokens := &tokenData{}
 
 	//start envelope

--- a/encode_test.go
+++ b/encode_test.go
@@ -23,7 +23,7 @@ func TestClient_MarshalXML(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err = soap.Call("checkVat", test.Params)
+		_, err = soap.Call("checkVat", test.Params)
 		if err == nil {
 			t.Errorf(test.Err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,6 @@
 module github.com/tiaguinho/gosoap
+
+require (
+	golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3
+	golang.org/x/text v0.3.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3 h1:ulvT7fqt0yHWzpJwI57MezWnYDVpCAYBVuYst/L+fAY=
+golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/request.go
+++ b/request.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 )
 
+// Soap Request
 type Request struct {
 	Method string
 	Params Params

--- a/request.go
+++ b/request.go
@@ -1,0 +1,29 @@
+package gosoap
+
+import (
+	"fmt"
+)
+
+type Request struct {
+	Method string
+	Params Params
+}
+
+func NewRequest(m string, p Params) *Request {
+	return &Request{
+		Method: m,
+		Params: p,
+	}
+}
+
+type RequestStruct interface {
+	SoapBuildRequest() *Request
+}
+
+func NewRequestByStruct(s RequestStruct) (*Request, error) {
+	if s == nil {
+		return nil, fmt.Errorf("'s' cannot be 'nil'")
+	}
+
+	return s.SoapBuildRequest(), nil
+}

--- a/response.go
+++ b/response.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 )
 
+// Soap Response
 type Response struct {
 	Body    []byte
 	Header  []byte

--- a/response.go
+++ b/response.go
@@ -1,0 +1,27 @@
+package gosoap
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+type Response struct {
+	Body    []byte
+	Header  []byte
+	Payload []byte
+}
+
+// Unmarshal get the body and unmarshal into the interface
+func (r *Response) Unmarshal(v interface{}) error {
+	if len(r.Body) == 0 {
+		return fmt.Errorf("Body is empty")
+	}
+
+	var f Fault
+	xml.Unmarshal(r.Body, &f)
+	if f.Code != "" {
+		return fmt.Errorf("[%s]: %s", f.Code, f.Description)
+	}
+
+	return xml.Unmarshal(r.Body, v)
+}

--- a/soap.go
+++ b/soap.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	
+
 	"golang.org/x/net/html/charset"
 )
 
@@ -35,6 +35,7 @@ func SoapClient(wsdl string) (*Client, error) {
 		WSDL:        wsdl,
 		URL:         strings.TrimSuffix(d.TargetNamespace, "/"),
 		Definitions: d,
+		HttpClient:  &http.Client{},
 	}
 
 	return c, nil
@@ -46,50 +47,55 @@ type Client struct {
 	HttpClient   *http.Client
 	WSDL         string
 	URL          string
-	Method       string
-	SoapAction   string
-	Params       Params
 	HeaderName   string
 	HeaderParams HeaderParams
 	Definitions  *wsdlDefinitions
-	Body         []byte
-	Header       []byte
 	Username     string
 	Password     string
-
-	payload []byte
-}
-
-// GetLastRequest returns the last request
-func (c *Client) GetLastRequest() []byte {
-	return c.payload
 }
 
 // Call call's the method m with Params p
-func (c *Client) Call(m string, p Params) (err error) {
+func (c *Client) Call(m string, p Params) (res *Response, err error) {
+	return c.Do(NewRequest(m, p))
+}
+
+// Call call's by struct
+func (c *Client) CallByStruct(s RequestStruct) (res *Response, err error) {
+	req, err := NewRequestByStruct(s)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Do(req)
+}
+
+func (c *Client) Do(req *Request) (res *Response, err error) {
 	if c.Definitions == nil {
-		return errors.New("WSDL definitions not found")
+		return nil, errors.New("WSDL definitions not found")
 	}
 
 	if c.Definitions.Services == nil {
-		return errors.New("No Services found in WSDL definitions")
+		return nil, errors.New("No Services found in WSDL definitions")
 	}
 
-	c.Method = m
-	c.Params = p
-	c.SoapAction = c.Definitions.GetSoapActionFromWsdlOperation(c.Method)
-	if c.SoapAction == "" {
-		c.SoapAction = fmt.Sprintf("%s/%s", c.URL, c.Method)
+	p := &process{
+		Client:     c,
+		Request:    req,
+		SoapAction: c.Definitions.GetSoapActionFromWsdlOperation(req.Method),
 	}
 
-	c.payload, err = xml.MarshalIndent(c, "", "    ")
+	if p.SoapAction == "" {
+		p.SoapAction = fmt.Sprintf("%s/%s", c.URL, req.Method)
+	}
+
+	p.Payload, err = xml.MarshalIndent(p, "", "    ")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	b, err := c.doRequest(c.Definitions.Services[0].Ports[0].SoapAddresses[0].Location)
+	b, err := p.doRequest(c.Definitions.Services[0].Ports[0].SoapAddresses[0].Location)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var soap SoapEnvelope
@@ -98,54 +104,45 @@ func (c *Client) Call(m string, p Params) (err error) {
 	// https://stackoverflow.com/questions/6002619/unmarshal-an-iso-8859-1-xml-input-in-go
 	// https://github.com/golang/go/issues/8937
 
-        decoder := xml.NewDecoder( bytes.NewReader(b) )
-        decoder.CharsetReader = charset.NewReaderLabel
-        err = decoder.Decode(&soap)
+	decoder := xml.NewDecoder(bytes.NewReader(b))
+	decoder.CharsetReader = charset.NewReaderLabel
+	err = decoder.Decode(&soap)
 
-	c.Body = soap.Body.Contents
-	c.Header = soap.Header.Contents
+	res = &Response{
+		Body:    soap.Body.Contents,
+		Header:  soap.Header.Contents,
+		Payload: p.Payload,
+	}
 
-	return err
+	return res, err
 }
 
-// Unmarshal get the body and unmarshal into the interface
-func (c *Client) Unmarshal(v interface{}) error {
-	if len(c.Body) == 0 {
-		return fmt.Errorf("Body is empty")
-	}
-
-	var f Fault
-	xml.Unmarshal(c.Body, &f)
-	if f.Code != "" {
-		return fmt.Errorf("[%s]: %s", f.Code, f.Description)
-	}
-
-	return xml.Unmarshal(c.Body, v)
+type process struct {
+	Client     *Client
+	Request    *Request
+	SoapAction string
+	Payload    []byte
 }
 
 // doRequest makes new request to the server using the c.Method, c.URL and the body.
-// body is enveloped in Call method
-func (c *Client) doRequest(url string) ([]byte, error) {
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(c.payload))
+// body is enveloped in Do method
+func (p *process) doRequest(url string) ([]byte, error) {
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(p.Payload))
 	if err != nil {
 		return nil, err
 	}
 
-	if c.Username != "" && c.Password != "" {
-		req.SetBasicAuth(c.Username, c.Password)
+	if p.Client.Username != "" && p.Client.Password != "" {
+		req.SetBasicAuth(p.Client.Username, p.Client.Password)
 	}
 
-	if c.HttpClient == nil {
-		c.HttpClient = &http.Client{}
-	}
-
-	req.ContentLength = int64(len(c.payload))
+	req.ContentLength = int64(len(p.Payload))
 
 	req.Header.Add("Content-Type", "text/xml;charset=UTF-8")
 	req.Header.Add("Accept", "text/xml")
-	req.Header.Add("SOAPAction", c.SoapAction)
+	req.Header.Add("SOAPAction", p.SoapAction)
 
-	resp, err := c.HttpClient.Do(req)
+	resp, err := p.Client.HttpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/soap.go
+++ b/soap.go
@@ -98,6 +98,7 @@ func (c *Client) SetWSDL(wsdl string) {
 	c.initWsdl()
 }
 
+// Process Soap Request
 func (c *Client) Do(req *Request) (res *Response, err error) {
 	c.onDefinitionsRefresh.Wait()
 	c.onRequest.Add(1)

--- a/soap.go
+++ b/soap.go
@@ -39,11 +39,12 @@ func SoapClient(wsdl string) (*Client, error) {
 // Client struct hold all the informations about wsdl,
 // request and response of the server
 type Client struct {
-	HttpClient              *http.Client
-	URL                     string
-	HeaderName              string
-	HeaderParams            HeaderParams
-	Definitions             *wsdlDefinitions
+	HttpClient   *http.Client
+	URL          string
+	HeaderName   string
+	HeaderParams HeaderParams
+	Definitions  *wsdlDefinitions
+	// Must be set before first request otherwise has no effect, minimum is 15 minutes.
 	RefreshDefinitionsAfter time.Duration
 	Username                string
 	Password                string

--- a/soap.go
+++ b/soap.go
@@ -21,7 +21,7 @@ type HeaderParams map[string]string
 // Params type is used to set the params in soap request
 type Params map[string]interface{}
 
-// SoapClient return new *Client to handle the requests with the wsdl
+// SoapClient return new *Client to handle the requests with the WSDL
 func SoapClient(wsdl string) (*Client, error) {
 	_, err := url.Parse(wsdl)
 	if err != nil {
@@ -36,7 +36,7 @@ func SoapClient(wsdl string) (*Client, error) {
 	return c, nil
 }
 
-// Client struct hold all the informations about wsdl,
+// Client struct hold all the informations about WSDL,
 // request and response of the server
 type Client struct {
 	HttpClient   *http.Client

--- a/soap.go
+++ b/soap.go
@@ -192,13 +192,20 @@ func (p *process) doRequest(url string) ([]byte, error) {
 	req.Header.Add("Accept", "text/xml")
 	req.Header.Add("SOAPAction", p.SoapAction)
 
-	resp, err := p.Client.HttpClient.Do(req)
+	resp, err := p.httpClient().Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	return ioutil.ReadAll(resp.Body)
+}
+
+func (p *process) httpClient() *http.Client {
+	if p.Client.HttpClient != nil {
+		return p.Client.HttpClient
+	}
+	return http.DefaultClient
 }
 
 type ErrorWithPayload struct {

--- a/soap_test.go
+++ b/soap_test.go
@@ -105,7 +105,7 @@ func TestClient_Call(t *testing.T) {
 		t.Errorf("error: %+v", rv)
 	}
 
-	soap, err = SoapClient("http://webservices.oorsprong.org/websamples.countryinfo/CountryInfoService.wso?wsdl")
+	soap, err = SoapClient("http://webservices.oorsprong.org/websamples.countryinfo/CountryInfoService.wso?WSDL")
 	if err != nil {
 		t.Errorf("error not expected: %s", err)
 	}
@@ -121,7 +121,7 @@ func TestClient_Call(t *testing.T) {
 		t.Errorf("error: %+v", rc)
 	}
 
-	soap, err = SoapClient("http://www.dataaccess.com/webservicesserver/numberconversion.wso?wsdl")
+	soap, err = SoapClient("http://www.dataaccess.com/webservicesserver/numberconversion.wso?WSDL")
 	if err != nil {
 		t.Errorf("error not expected: %s", err)
 	}
@@ -137,7 +137,7 @@ func TestClient_Call(t *testing.T) {
 		t.Errorf("error: %+v", rn)
 	}
 
-	soap, err = SoapClient("https://domains.livedns.co.il/API/DomainsAPI.asmx?wsdl")
+	soap, err = SoapClient("https://domains.livedns.co.il/API/DomainsAPI.asmx?WSDL")
 	if err != nil {
 		t.Errorf("error not expected: %s", err)
 	}
@@ -163,7 +163,7 @@ func TestClient_Call(t *testing.T) {
 
 	res, err = c.Call("checkVat", params)
 	if err == nil {
-		t.Errorf("invalid wsdl")
+		t.Errorf("invalid WSDL")
 	}
 }
 
@@ -215,6 +215,6 @@ func TestProcess_doRequest(t *testing.T) {
 
 	_, err = c.doRequest("://teste.")
 	if err == nil {
-		t.Errorf("invalid wsdl")
+		t.Errorf("invalid WSDL")
 	}
 }

--- a/soap_test.go
+++ b/soap_test.go
@@ -105,7 +105,7 @@ func TestClient_Call(t *testing.T) {
 		t.Errorf("error: %+v", rv)
 	}
 
-	soap, err = SoapClient("http://webservices.oorsprong.org/websamples.countryinfo/CountryInfoService.wso?WSDL")
+	soap, err = SoapClient("http://webservices.oorsprong.org/websamples.countryinfo/CountryInfoService.wso?wsdl")
 	if err != nil {
 		t.Errorf("error not expected: %s", err)
 	}
@@ -121,7 +121,7 @@ func TestClient_Call(t *testing.T) {
 		t.Errorf("error: %+v", rc)
 	}
 
-	soap, err = SoapClient("http://www.dataaccess.com/webservicesserver/numberconversion.wso?WSDL")
+	soap, err = SoapClient("http://www.dataaccess.com/webservicesserver/numberconversion.wso?wsdl")
 	if err != nil {
 		t.Errorf("error not expected: %s", err)
 	}
@@ -137,7 +137,7 @@ func TestClient_Call(t *testing.T) {
 		t.Errorf("error: %+v", rn)
 	}
 
-	soap, err = SoapClient("https://domains.livedns.co.il/API/DomainsAPI.asmx?WSDL")
+	soap, err = SoapClient("https://domains.livedns.co.il/API/DomainsAPI.asmx?wsdl")
 	if err != nil {
 		t.Errorf("error not expected: %s", err)
 	}
@@ -159,11 +159,11 @@ func TestClient_Call(t *testing.T) {
 		t.Errorf("error expected but nothing got.")
 	}
 
-	c.WSDL = "://test."
+	c.SetWSDL("://test.")
 
 	res, err = c.Call("checkVat", params)
 	if err == nil {
-		t.Errorf("invalid WSDL")
+		t.Errorf("invalid wsdl")
 	}
 }
 
@@ -215,6 +215,6 @@ func TestProcess_doRequest(t *testing.T) {
 
 	_, err = c.doRequest("://teste.")
 	if err == nil {
-		t.Errorf("invalid WSDL")
+		t.Errorf("invalid wsdl")
 	}
 }


### PR DESCRIPTION
**Note:** this introduces changes to the API, this has backward incompatible changes.

* Refactored Soap Client, so the API is similar to Google's net/http Client
  * Introduce **Request** and **Response** data types, Client no longer holds states on request and response, it's move to the new data types.
  * Removed **GetLastRequest** from **Client**, as the Payload gets return on **Response** or **error**, use the new function **GetPayloadFromError** to pull the payload from error.
  * Moved **MarshallXML** to a hidden data type **process**
  * Moved **Unmarshal** to Response
  * WSDL Definitions is initialised on first request.
  * Added **RefreshDefinitionsAfter** field to Client, must be set before first request otherwise won't have any effect, minimum is 15 minutes.
  * Added **Do** method to **Client**, quite similar to Google's net/http Client **Do** method
  * **Call** now also returns **Response**, and it's also a shortcut to **Do**
  * Added **CallByStruct** to **Client** look at the test case `soap_test.go` to see how that works.
* Remove side effect (or `var tokens []xml.Token`) as that can cause race conditions.