### PR TITLE
composite header params

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -18,16 +18,8 @@ func (c process) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
 	tokens.startEnvelope()
 	if len(c.Client.HeaderParams) > 0 {
 		tokens.startHeader(c.Client.HeaderName, c.Client.Definitions.Types[0].XsdSchema[0].TargetNamespace)
-		for k, v := range c.Client.HeaderParams {
-			t := xml.StartElement{
-				Name: xml.Name{
-					Space: "",
-					Local: k,
-				},
-			}
 
-			tokens.data = append(tokens.data, t, xml.CharData(v), xml.EndElement{Name: t.Name})
-		}
+		tokens.recursiveEncode(c.Client.HeaderParams)
 
 		tokens.endHeader(c.Client.HeaderName)
 	}

--- a/soap.go
+++ b/soap.go
@@ -16,7 +16,7 @@ import (
 )
 
 // HeaderParams holds params specific to the header
-type HeaderParams map[string]string
+type HeaderParams map[string]interface{}
 
 // Params type is used to set the params in soap request
 type Params map[string]interface{}


### PR DESCRIPTION
fix: https://github.com/tiaguinho/gosoap/issues/31

this allows to set `map[string]interface{}` as HeaderParams, but it is still not possible to change the namespace

this PR is to be able to add WSS headers https://en.wikipedia.org/wiki/WS-Security