### PR TITLE
Modification to allow attributes in SOAP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ func main() {
 	}
 
 	params := gosoap.Params{
-		"sIp": "8.8.8.8",
+		"sIp[type=s:string,anotherAttribute=anotherValue]": "8.8.8.8",
 	}
 
 	res, err := soap.Call("GetIpLocation", params)


### PR DESCRIPTION
Hi,

The SOAP WS that I'm using needs some attributes in the SOAP requests. There was a similar idea in issue #8 made by cscholle1.

Here's my working proposal:
`params := gosoap.Params{
		"sIp[type=s:string,anotherAttribute=anotherValue]": "8.8.8.8",
	}
`
Thx,
kvbkvm