### PR TITLE
HTTP client can be configurate outside the SOAP module.

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -170,10 +170,10 @@ func (tokens *tokenData) startBody(m, n string) error {
 	r := xml.StartElement{
 		Name: xml.Name{
 			Space: "",
-			Local: m,
+			Local: "ws:" + m,
 		},
 		Attr: []xml.Attr{
-			{Name: xml.Name{Space: "", Local: "xmlns"}, Value: n},
+			{Name: xml.Name{Space: "", Local: "xmlns:ws"}, Value: n},
 		},
 	}
 
@@ -194,7 +194,7 @@ func (tokens *tokenData) endBody(m string) {
 	r := xml.EndElement{
 		Name: xml.Name{
 			Space: "",
-			Local: m,
+			Local: "ws:" + m,
 		},
 	}
 

--- a/encode.go
+++ b/encode.go
@@ -154,7 +154,6 @@ func (tokens *tokenData) endHeader(m string) {
 	tokens.data = append(tokens.data, r, h)
 }
 
-// startToken initiate body of the envelope
 func (tokens *tokenData) startBody(m, n string) error {
 	b := xml.StartElement{
 		Name: xml.Name{
@@ -170,10 +169,10 @@ func (tokens *tokenData) startBody(m, n string) error {
 	r := xml.StartElement{
 		Name: xml.Name{
 			Space: "",
-			Local: "ws:" + m,
+			Local: m,
 		},
 		Attr: []xml.Attr{
-			{Name: xml.Name{Space: "", Local: "xmlns:ws"}, Value: n},
+			{Name: xml.Name{Space: "", Local: "xmlns"}, Value: n},
 		},
 	}
 
@@ -194,7 +193,7 @@ func (tokens *tokenData) endBody(m string) {
 	r := xml.EndElement{
 		Name: xml.Name{
 			Space: "",
-			Local: "ws:" + m,
+			Local: m,
 		},
 	}
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -17,7 +17,7 @@ var (
 )
 
 func TestClient_MarshalXML(t *testing.T) {
-	soap, err := SoapClient("http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl")
+	soap, err := SoapClient("http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl", nil)
 	if err != nil {
 		t.Errorf("error not expected: %s", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,3 +4,5 @@ require (
 	golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3
 	golang.org/x/text v0.3.0 // indirect
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/tiaguinho/gosoap
 
 require (
-	golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3
-	golang.org/x/text v0.3.0 // indirect
+	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553
+	golang.org/x/text v0.3.2 // indirect
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,11 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3 h1:ulvT7fqt0yHWzpJwI57MezWnYDVpCAYBVuYst/L+fAY=
 golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8oukgn+8D8WgaCaRMchF8=
+golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/request.go
+++ b/request.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 )
 
-// Soap Request
+// Request Soap Request
 type Request struct {
 	Method string
 	Params Params
 }
 
+// NewRequest creates a new soap request
 func NewRequest(m string, p Params) *Request {
 	return &Request{
 		Method: m,
@@ -17,10 +18,12 @@ func NewRequest(m string, p Params) *Request {
 	}
 }
 
+// RequestStruct soap request interface
 type RequestStruct interface {
 	SoapBuildRequest() *Request
 }
 
+// NewRequestByStruct create a new request using builder
 func NewRequestByStruct(s RequestStruct) (*Request, error) {
 	if s == nil {
 		return nil, fmt.Errorf("'s' cannot be 'nil'")

--- a/response.go
+++ b/response.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// Soap Response
+// Response Soap Response
 type Response struct {
 	Body    []byte
 	Header  []byte

--- a/soap.go
+++ b/soap.go
@@ -137,7 +137,7 @@ func (c *Client) Do(req *Request) (res *Response, err error) {
 	}
 
 	if p.SoapAction == "" {
-		p.SoapAction = fmt.Sprintf("%s/%s", c.URL, req.Method)
+		p.SoapAction = fmt.Sprintf("%s/%s/%s", c.URL, c.Definitions.Services[0].Name, req.Method)
 	}
 
 	p.Payload, err = xml.MarshalIndent(p, "", "    ")

--- a/soap.go
+++ b/soap.go
@@ -22,15 +22,19 @@ type HeaderParams map[string]interface{}
 type Params map[string]interface{}
 
 // SoapClient return new *Client to handle the requests with the WSDL
-func SoapClient(wsdl string) (*Client, error) {
+func SoapClient(wsdl string, httpClient *http.Client) (*Client, error) {
 	_, err := url.Parse(wsdl)
 	if err != nil {
 		return nil, err
 	}
 
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+
 	c := &Client{
 		wsdl:       wsdl,
-		HttpClient: &http.Client{},
+		HTTPClient: httpClient,
 	}
 
 	return c, nil
@@ -39,7 +43,7 @@ func SoapClient(wsdl string) (*Client, error) {
 // Client struct hold all the informations about WSDL,
 // request and response of the server
 type Client struct {
-	HttpClient   *http.Client
+	HTTPClient   *http.Client
 	URL          string
 	HeaderName   string
 	HeaderParams HeaderParams
@@ -61,7 +65,7 @@ func (c *Client) Call(m string, p Params) (res *Response, err error) {
 	return c.Do(NewRequest(m, p))
 }
 
-// Call call's by struct
+// CallByStruct call's by struct
 func (c *Client) CallByStruct(s RequestStruct) (res *Response, err error) {
 	req, err := NewRequestByStruct(s)
 	if err != nil {
@@ -82,12 +86,13 @@ func (c *Client) waitAndRefreshDefinitions(d time.Duration) {
 }
 
 func (c *Client) initWsdl() {
-	c.Definitions, c.definitionsErr = getWsdlDefinitions(c.wsdl)
+	c.Definitions, c.definitionsErr = getWsdlDefinitions(c.wsdl, c.HTTPClient)
 	if c.definitionsErr == nil {
 		c.URL = strings.TrimSuffix(c.Definitions.TargetNamespace, "/")
 	}
 }
 
+// SetWSDL set WSDL url
 func (c *Client) SetWSDL(wsdl string) {
 	c.onRequest.Wait()
 	c.onDefinitionsRefresh.Wait()
@@ -99,7 +104,7 @@ func (c *Client) SetWSDL(wsdl string) {
 	c.initWsdl()
 }
 
-// Process Soap Request
+// Do Process Soap Request
 func (c *Client) Do(req *Request) (res *Response, err error) {
 	c.onDefinitionsRefresh.Wait()
 	c.onRequest.Add(1)
@@ -202,17 +207,19 @@ func (p *process) doRequest(url string) ([]byte, error) {
 }
 
 func (p *process) httpClient() *http.Client {
-	if p.Client.HttpClient != nil {
-		return p.Client.HttpClient
+	if p.Client.HTTPClient != nil {
+		return p.Client.HTTPClient
 	}
 	return http.DefaultClient
 }
 
+// ErrorWithPayload error payload schema
 type ErrorWithPayload struct {
 	error
 	Payload []byte
 }
 
+// GetPayloadFromError returns the payload of a ErrorWithPayload
 func GetPayloadFromError(err error) []byte {
 	if err, ok := err.(ErrorWithPayload); ok {
 		return err.Payload

--- a/soap.go
+++ b/soap.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -34,6 +35,7 @@ func SoapClient(wsdl string, httpClient *http.Client) (*Client, error) {
 	c := &Client{
 		wsdl:       wsdl,
 		HTTPClient: httpClient,
+		AutoAction: false,
 	}
 
 	return c, nil
@@ -43,6 +45,7 @@ func SoapClient(wsdl string, httpClient *http.Client) (*Client, error) {
 // request and response of the server
 type Client struct {
 	HTTPClient   *http.Client
+	AutoAction   bool
 	URL          string
 	HeaderName   string
 	HeaderParams HeaderParams
@@ -135,9 +138,9 @@ func (c *Client) Do(req *Request) (res *Response, err error) {
 		SoapAction: c.Definitions.GetSoapActionFromWsdlOperation(req.Method),
 	}
 
-	// if p.SoapAction == "" {
-	// 	p.SoapAction = fmt.Sprintf("%s/%s/%s", c.URL, c.Definitions.Services[0].Name, req.Method)
-	// }
+	if p.SoapAction == "" && c.AutoAction {
+		p.SoapAction = fmt.Sprintf("%s/%s/%s", c.URL, c.Definitions.Services[0].Name, req.Method)
+	}
 
 	p.Payload, err = xml.MarshalIndent(p, "", "    ")
 	if err != nil {

--- a/soap.go
+++ b/soap.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/xml"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -136,9 +135,9 @@ func (c *Client) Do(req *Request) (res *Response, err error) {
 		SoapAction: c.Definitions.GetSoapActionFromWsdlOperation(req.Method),
 	}
 
-	if p.SoapAction == "" {
-		p.SoapAction = fmt.Sprintf("%s/%s/%s", c.URL, c.Definitions.Services[0].Name, req.Method)
-	}
+	// if p.SoapAction == "" {
+	// 	p.SoapAction = fmt.Sprintf("%s/%s/%s", c.URL, c.Definitions.Services[0].Name, req.Method)
+	// }
 
 	p.Payload, err = xml.MarshalIndent(p, "", "    ")
 	if err != nil {

--- a/soap_test.go
+++ b/soap_test.go
@@ -1,14 +1,16 @@
 package gosoap
 
 import (
+	"crypto/tls"
 	"net/http"
 	"testing"
 )
 
 var (
 	scts = []struct {
-		URL string
-		Err bool
+		URL    string
+		Err    bool
+		Client *http.Client
 	}{
 		{
 			URL: "://www.server",
@@ -22,15 +24,38 @@ var (
 			URL: "http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl",
 			Err: true,
 		},
+		{
+			URL: "http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl",
+			Err: true,
+			Client: &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{
+						InsecureSkipVerify: true,
+					},
+				},
+			},
+		},
 	}
 )
 
 func TestSoapClient(t *testing.T) {
 	for _, sct := range scts {
-		_, err := SoapClient(sct.URL)
+		_, err := SoapClient(sct.URL, nil)
 		if err != nil && sct.Err {
 			t.Errorf("URL: %s - error: %s", sct.URL, err)
 		}
+	}
+}
+
+func TestSoapClienWithClient(t *testing.T) {
+	client, err := SoapClient(scts[3].URL, scts[3].Client)
+
+	if client.HTTPClient != scts[3].Client {
+		t.Errorf("HTTP client is not the same as in initialization: - error: %s", err)
+	}
+
+	if err != nil {
+		t.Errorf("URL: %s - error: %s", scts[3].URL, err)
 	}
 }
 
@@ -77,7 +102,7 @@ var (
 )
 
 func TestClient_Call(t *testing.T) {
-	soap, err := SoapClient("http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl")
+	soap, err := SoapClient("http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl", nil)
 	if err != nil {
 		t.Errorf("error not expected: %s", err)
 	}
@@ -105,7 +130,7 @@ func TestClient_Call(t *testing.T) {
 		t.Errorf("error: %+v", rv)
 	}
 
-	soap, err = SoapClient("http://webservices.oorsprong.org/websamples.countryinfo/CountryInfoService.wso?WSDL")
+	soap, err = SoapClient("http://webservices.oorsprong.org/websamples.countryinfo/CountryInfoService.wso?WSDL", nil)
 	if err != nil {
 		t.Errorf("error not expected: %s", err)
 	}
@@ -121,7 +146,7 @@ func TestClient_Call(t *testing.T) {
 		t.Errorf("error: %+v", rc)
 	}
 
-	soap, err = SoapClient("http://www.dataaccess.com/webservicesserver/numberconversion.wso?WSDL")
+	soap, err = SoapClient("http://www.dataaccess.com/webservicesserver/numberconversion.wso?WSDL", nil)
 	if err != nil {
 		t.Errorf("error not expected: %s", err)
 	}
@@ -137,7 +162,7 @@ func TestClient_Call(t *testing.T) {
 		t.Errorf("error: %+v", rn)
 	}
 
-	soap, err = SoapClient("https://domains.livedns.co.il/API/DomainsAPI.asmx?WSDL")
+	soap, err = SoapClient("https://domains.livedns.co.il/API/DomainsAPI.asmx?WSDL", nil)
 	if err != nil {
 		t.Errorf("error not expected: %s", err)
 	}
@@ -168,7 +193,7 @@ func TestClient_Call(t *testing.T) {
 }
 
 func TestClient_CallByStruct(t *testing.T) {
-	soap, err := SoapClient("http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl")
+	soap, err := SoapClient("http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl", nil)
 	if err != nil {
 		t.Errorf("error not expected: %s", err)
 	}
@@ -190,7 +215,7 @@ func TestClient_CallByStruct(t *testing.T) {
 }
 
 func TestClient_Call_NonUtf8(t *testing.T) {
-	soap, err := SoapClient("https://demo.ilias.de/webservice/soap/server.php?wsdl")
+	soap, err := SoapClient("https://demo.ilias.de/webservice/soap/server.php?wsdl", nil)
 	if err != nil {
 		t.Errorf("error not expected: %s", err)
 	}
@@ -204,7 +229,7 @@ func TestClient_Call_NonUtf8(t *testing.T) {
 func TestProcess_doRequest(t *testing.T) {
 	c := &process{
 		Client: &Client{
-			HttpClient: &http.Client{},
+			HTTPClient: &http.Client{},
 		},
 	}
 

--- a/wsdl.go
+++ b/wsdl.go
@@ -2,11 +2,12 @@ package gosoap
 
 import (
 	"encoding/xml"
-	"golang.org/x/net/html/charset"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
+
+	"golang.org/x/net/html/charset"
 )
 
 type wsdlDefinitions struct {

--- a/wsdl.go
+++ b/wsdl.go
@@ -155,7 +155,7 @@ type xsdMaxInclusive struct {
 	Value string `xml:"value,attr"`
 }
 
-func getWsdlBody(u string) (reader io.ReadCloser, err error) {
+func getWsdlBody(u string, httpClient *http.Client) (reader io.ReadCloser, err error) {
 	parse, err := url.Parse(u)
 	if err != nil {
 		return nil, err
@@ -167,7 +167,10 @@ func getWsdlBody(u string) (reader io.ReadCloser, err error) {
 		}
 		return outFile, nil
 	}
-	r, err := http.Get(u)
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	r, err := httpClient.Get(u)
 	if err != nil {
 		return nil, err
 	}
@@ -175,8 +178,8 @@ func getWsdlBody(u string) (reader io.ReadCloser, err error) {
 }
 
 // getWsdlDefinitions sent request to the wsdl url and set definitions on struct
-func getWsdlDefinitions(u string) (wsdl *wsdlDefinitions, err error) {
-	reader, err := getWsdlBody(u)
+func getWsdlDefinitions(u string, httpClient *http.Client) (wsdl *wsdlDefinitions, err error) {
+	reader, err := getWsdlBody(u, httpClient)
 	if err != nil {
 		return nil, err
 	}

--- a/wsdl_test.go
+++ b/wsdl_test.go
@@ -49,7 +49,7 @@ func Test_getWsdlBody(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := getWsdlBody(tt.args.u)
+			_, err := getWsdlBody(tt.args.u, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getwsdlBody() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Using an external HTTP Client allows the users to have more control over how he communicates with the service.

For example, adding certificates to the transport configuration.

```
httpClient := &http.Client{
  Transport: &http.Transport{
    TLSClientConfig: &tls.Config{
      InsecureSkipVerify: true,
    },
  },
}

soapClient := gosoap.SoapClient(url, httpClient)
```

And any kind of configuration for the HTTP Client will apply even though when the library is getting the definitions.

