### PR TITLE
Throw an error if WSDL request fails with status code < 200 or > 400

### DIFF
--- a/soap.go
+++ b/soap.go
@@ -20,7 +20,7 @@ import (
 type HeaderParams map[string]interface{}
 
 // Params type is used to set the params in soap request
-type SoapParams interface {}
+type SoapParams interface{}
 type Params map[string]interface{}
 type ArrayParams [][2]interface{}
 
@@ -234,6 +234,10 @@ func (p *process) doRequest(url string) ([]byte, error) {
 			return nil, err
 		}
 		fmt.Printf("Response:\n%v\n----\n", string(dump))
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return nil, errors.New("unexpected status code: " + resp.Status)
 	}
 
 	return ioutil.ReadAll(resp.Body)

--- a/soap_test.go
+++ b/soap_test.go
@@ -102,8 +102,8 @@ var (
 )
 
 func TestClient_Call(t *testing.T) {
-	soap, err := SoapClientWithConfig("http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl", 
-    nil,
+	soap, err := SoapClientWithConfig("http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl",
+		nil,
 		&Config{Dump: true},
 	)
 	if err != nil {
@@ -249,5 +249,14 @@ func TestProcess_doRequest(t *testing.T) {
 	_, err = c.doRequest("://teste.")
 	if err == nil {
 		t.Errorf("invalid WSDL")
+	}
+
+	_, err = c.doRequest("https://google.com/non-existent-url")
+	if err == nil {
+		t.Errorf("err can't be nil")
+	}
+
+	if err != nil && err.Error() != "unexpected status code: 404 Not Found" {
+		t.Errorf("unexpected error: %s", err)
 	}
 }


### PR DESCRIPTION
Throws an error in doRequest() if remote server answers with one of the "unsuccessful" codes: everything less than 200 or bigger than 400.

Fixes #66