### PR TITLE
Verbose error message if WSDL request fails with status code < 200 or > 400

### DIFF
--- a/soap.go
+++ b/soap.go
@@ -237,7 +237,13 @@ func (p *process) doRequest(url string) ([]byte, error) {
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		return nil, errors.New("unexpected status code: " + resp.Status)
+		responseBodyBytes, err := ioutil.ReadAll(resp.Body)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, fmt.Errorf("Unexpected status code: %d.\nDetail: %s", resp.StatusCode, responseBodyBytes)
 	}
 
 	return ioutil.ReadAll(resp.Body)

--- a/soap.go
+++ b/soap.go
@@ -240,7 +240,7 @@ func (p *process) doRequest(url string) ([]byte, error) {
 		responseBodyBytes, err := ioutil.ReadAll(resp.Body)
 
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Unexpected status code: %d", resp.StatusCode)
 		}
 
 		return nil, fmt.Errorf("Unexpected status code: %d.\nDetail: %s", resp.StatusCode, responseBodyBytes)


### PR DESCRIPTION
Hi!
It is useful when you see a full error message rather then just a payload.
I suggest just print bad response body. Or maybe do a configurable logging for user. 
What do you think?