### PR TITLE
improve xml encoding

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -34,11 +34,9 @@ func (c process) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
 	}
 
 	tokens.startEnvelope()
-	if len(c.Client.HeaderParams) > 0 {
+	if c.Client.HeaderParams != nil {
 		tokens.startHeader(c.Client.HeaderName, namespace)
-
 		tokens.recursiveEncode(c.Client.HeaderParams)
-
 		tokens.endHeader(c.Client.HeaderName)
 	}
 
@@ -105,6 +103,8 @@ func (tokens *tokenData) recursiveEncode(hm interface{}) {
 	case reflect.String:
 		content := xml.CharData(v.String())
 		tokens.data = append(tokens.data, content)
+	case reflect.Struct:
+		tokens.data = append(tokens.data, v.Interface())
 	}
 }
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -1,6 +1,7 @@
 package gosoap
 
 import (
+	"encoding/xml"
 	"testing"
 )
 
@@ -30,7 +31,7 @@ var (
 		Err    string
 	}{
 		{
-			Params: SliceParams{"", ""},
+			Params: SliceParams{xml.StartElement{}, xml.EndElement{}},
 			Err:    "error expected: xml: start tag with no name",
 		},
 	}

--- a/encode_test.go
+++ b/encode_test.go
@@ -24,6 +24,16 @@ var (
 			Err:    "error expected: xml: start tag with no name",
 		},
 	}
+
+	sliceParamsTests = []struct {
+		Params SliceParams
+		Err    string
+	}{
+		{
+			Params: SliceParams{"", ""},
+			Err:    "error expected: xml: start tag with no name",
+		},
+	}
 )
 
 func TestClient_MarshalXML(t *testing.T) {
@@ -61,6 +71,20 @@ func TestClient_MarshalXML3(t *testing.T) {
 	}
 
 	for _, test := range mapParamsTests {
+		_, err = soap.Call("checkVat", test.Params)
+		if err == nil {
+			t.Errorf(test.Err)
+		}
+	}
+}
+
+func TestClient_MarshalXML4(t *testing.T) {
+	soap, err := SoapClient("http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl", nil)
+	if err != nil {
+		t.Errorf("error not expected: %s", err)
+	}
+
+	for _, test := range sliceParamsTests {
 		_, err = soap.Call("checkVat", test.Params)
 		if err == nil {
 			t.Errorf(test.Err)

--- a/soap.go
+++ b/soap.go
@@ -16,13 +16,15 @@ import (
 	"golang.org/x/net/html/charset"
 )
 
+type SoapParams interface{}
+
 // HeaderParams holds params specific to the header
 type HeaderParams map[string]interface{}
 
 // Params type is used to set the params in soap request
-type SoapParams interface{}
 type Params map[string]interface{}
 type ArrayParams [][2]interface{}
+type SliceParams []interface{}
 
 type DumpLogger interface {
 	LogRequest(method string, dump []byte)
@@ -82,7 +84,7 @@ type Client struct {
 	AutoAction   bool
 	URL          string
 	HeaderName   string
-	HeaderParams HeaderParams
+	HeaderParams SoapParams
 	Definitions  *wsdlDefinitions
 	// Must be set before first request otherwise has no effect, minimum is 15 minutes.
 	RefreshDefinitionsAfter time.Duration


### PR DESCRIPTION
Added ability to define header and body params as:
```go
	soap.HeaderParams = gosoap.SliceParams{
		xml.StartElement{
			Name: xml.Name{
				Space: "auth",
				Local: "Login",
			},
		},
		"user",
		xml.EndElement{
			Name: xml.Name{
				Space: "auth",
				Local: "Login",
			},
		},
		xml.StartElement{
			Name: xml.Name{
				Space: "auth",
				Local: "Password",
			},
		},
		"P@ssw0rd",
		xml.EndElement{
			Name: xml.Name{
				Space: "auth",
				Local: "Password",
			},
		},
	}
```

Also fix #37 and partial #46
