### PR TITLE
fix: should drain resp.Body if not readAll or dump

### DIFF
--- a/soap.go
+++ b/soap.go
@@ -5,6 +5,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
@@ -261,6 +262,12 @@ func (p *process) doRequest(url string) ([]byte, error) {
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		if !(p.Client.config != nil && p.Client.config.Dump) {
+			_, err := io.Copy(ioutil.Discard, resp.Body)
+			if err != nil {
+				return nil, err
+			}
+		}
 		return nil, errors.New("unexpected status code: " + resp.Status)
 	}
 


### PR DESCRIPTION
refs:
https://pkg.go.dev/net/http#Client.Do
https://forum.golangbridge.org/t/do-i-need-to-read-the-body-before-close-it/5594
https://github.com/google/go-github/pull/317