### PR TITLE
Allow passing complex structs to CallByStruct

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 var (
@@ -110,10 +111,16 @@ func (tokens *tokenData) recursiveEncode(hm interface{}) {
 	case reflect.Struct:
 		for i := 0; i < v.NumField(); i++ {
 			field := v.Field(i)
+			var name string
+			name = v.Type().Field(i).Tag.Get("xml")
+			if name == "" {
+				name = v.Type().Field(i).Name
+				name = strings.ToLower(name[0:1]) + name[1:]
+			}
 			t := xml.StartElement{
 				Name: xml.Name{
 					Space: "",
-					Local: v.Type().Field(i).Tag.Get("xml"),
+					Local: name,
 				},
 			}
 			tokens.data = append(tokens.data, t)

--- a/encode.go
+++ b/encode.go
@@ -108,7 +108,18 @@ func (tokens *tokenData) recursiveEncode(hm interface{}) {
 		content := xml.CharData(v.String())
 		tokens.data = append(tokens.data, content)
 	case reflect.Struct:
-		tokens.data = append(tokens.data, v.Interface())
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Field(i)
+			t := xml.StartElement{
+				Name: xml.Name{
+					Space: "",
+					Local: v.Type().Field(i).Tag.Get("xml"),
+				},
+			}
+			tokens.data = append(tokens.data, t)
+			tokens.recursiveEncode(field.Interface())
+			tokens.data = append(tokens.data, xml.EndElement{Name: t.Name})
+		}
 	}
 }
 

--- a/soap_test.go
+++ b/soap_test.go
@@ -63,8 +63,8 @@ func TestSoapClienWithClient(t *testing.T) {
 }
 
 type CheckVatRequest struct {
-	CountryCode string `xml:"countryCode"`
-	VatNumber   string `xml:"vatNumber"`
+	CountryCode string
+	VatNumber   string
 }
 
 func (r CheckVatRequest) SoapBuildRequest() *Request {

--- a/soap_test.go
+++ b/soap_test.go
@@ -63,15 +63,12 @@ func TestSoapClienWithClient(t *testing.T) {
 }
 
 type CheckVatRequest struct {
-	CountryCode string
-	VatNumber   string
+	CountryCode string `xml:"countryCode"`
+	VatNumber   string `xml:"vatNumber"`
 }
 
 func (r CheckVatRequest) SoapBuildRequest() *Request {
-	return NewRequest("checkVat", Params{
-		"countryCode": r.CountryCode,
-		"vatNumber":   r.VatNumber,
-	})
+	return NewRequest("checkVat", r)
 }
 
 type CheckVatResponse struct {


### PR DESCRIPTION
No need to create Params map anymore to use complex structs. 