### PR TITLE
fix: do not set SOAPAction header if the value is empty

### DIFF
--- a/soap.go
+++ b/soap.go
@@ -242,7 +242,9 @@ func (p *process) doRequest(url string) ([]byte, error) {
 
 	req.Header.Add("Content-Type", "text/xml;charset=UTF-8")
 	req.Header.Add("Accept", "text/xml")
-	req.Header.Add("SOAPAction", p.SoapAction)
+	if p.SoapAction != "" {
+		req.Header.Add("SOAPAction", p.SoapAction)
+	}
 
 	resp, err := p.httpClient().Do(req)
 	if err != nil {


### PR DESCRIPTION
Some APIs reject the SOAPAction header, so my suggestion is to omit it if empty.