### PR TITLE
fix: use right targetNamespace duing request marshal

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -31,7 +31,7 @@ func (c process) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
 	namespace := ""
 	if c.Client.Definitions.Types != nil {
 		schema := c.Client.Definitions.Types[0].XsdSchema[0]
-		namespace = schema.TargetNamespace
+		namespace = c.Client.Definitions.TargetNamespace
 		if namespace == "" && len(schema.Imports) > 0 {
 			namespace = schema.Imports[0].Namespace
 		}


### PR DESCRIPTION
During request marshal the namespace is not set correctly. Instead of
using from xsd:schema targetNamespace, it now uses the namespace from
wsld definitions.

Fixes: #48