### PR TITLE
fix: Extract SOAP URL from wsdl URL passed

### DIFF
--- a/soap.go
+++ b/soap.go
@@ -185,7 +185,8 @@ func (c *Client) Do(req *Request) (res *Response, err error) {
 		return nil, err
 	}
 
-	b, err := p.doRequest(c.Definitions.Services[0].Ports[0].SoapAddresses[0].Location)
+	soapURL := c.wsdl[:len(c.wsdl)-5]
+	b, err := p.doRequest(soapURL)
 	if err != nil {
 		return nil, ErrorWithPayload{err, p.Payload}
 	}


### PR DESCRIPTION
## Context
There are cases where wsdl URL starts with `https` but wsdl definition has URL starting with `http`. This makes it impossible to call https endpoint and it gives below error:
```
Expected element type <Envelope> but have <html>
```

## Changes
Extract SOAP URL from wsdl URL rather then taking it from wsdl definition