### PR TITLE
Added option to set User-Agent Header on client request. 

### DIFF
--- a/soap.go
+++ b/soap.go
@@ -91,6 +91,7 @@ type Client struct {
 	RefreshDefinitionsAfter time.Duration
 	Username                string
 	Password                string
+	UserAgent               string // Used to set user-agent header.
 
 	once                 sync.Once
 	definitionsErr       error
@@ -237,6 +238,11 @@ func (p *process) doRequest(url string) ([]byte, error) {
 
 	if p.Client.Username != "" && p.Client.Password != "" {
 		req.SetBasicAuth(p.Client.Username, p.Client.Password)
+	}
+
+	// Set user-agent if specified
+	if p.Client.UserAgent != "" {
+		req.Header.Add("User-Agent", p.Client.UserAgent)
 	}
 
 	req.ContentLength = int64(len(p.Payload))


### PR DESCRIPTION
`Client.UserAgent` field is used to set the header. If left empty default Go value is used.